### PR TITLE
Fixed toCDXLine digest field

### DIFF
--- a/src/main/java/uk/bl/wap/util/OutbackCDXClient.java
+++ b/src/main/java/uk/bl/wap/util/OutbackCDXClient.java
@@ -553,7 +553,7 @@ public class OutbackCDXClient {
         sb.append(" ");
         sb.append(fetch_status);
         sb.append(" ");
-        sb.append(curi.getContentDigestSchemeString());
+        sb.append(curi.getContentDigestString());
         sb.append(" ");
         sb.append(curi.flattenVia());
         sb.append(" ");


### PR DESCRIPTION
Fixed issue where `toCDXLine` generates a digest using the scheme prefix instead of the raw sha1 value. Now uses `getContentDigestString` instead of `getContentDigestSchemeString`.

By using `getContentDigestSchemeString`, the module would prepare the CDX Line with a digest such as `sha1:luwq7wuizbu3bgfqgpkfmplfx5sefgsy` rather than the correct version as `LUWQ7WUIZBU3BGFQGPKFMPLFX5SEFGSY`.

Prior to outbackcdx-0.11.0 the resulting digest would be parsed incorrectly and stored in a format such as `SHALUWQ7WUIZBU3BGFQGPKFMPLFX5S-----`.

In any case, when reading CDX records back out of Outback, they would never produce a positive match with a corresponding Heritrix digest.